### PR TITLE
タブ遷移ボタン復活

### DIFF
--- a/components/header.jsx
+++ b/components/header.jsx
@@ -17,8 +17,8 @@ export default function ButtonAppBar() {
     const matches = useMediaQuery(theme.breakpoints.up('sm'));
     const logo = matches ? logoHorizon : logoSmall;
     return (
-        <header>
-            <Image src={logo} alt="Application Logo" height={'100px'} layout='fixed' objectFit='contain'></Image>
+        <header className="app-header">
+            <Image src={logo} alt="Application Logo" height={"100%"} layout='fixed' objectFit='contain'></Image>
         </header>
         /*<Box>
             <AppBar position="static">

--- a/pages/input.js
+++ b/pages/input.js
@@ -6,7 +6,7 @@ import ResultTabComponent from '../components/resultTabComponent';
 import InputItem from '../components/inputItem';
 import  Tab from '@mui/material/Tab';
 import  Tabs from '@mui/material/Tabs';
-import { Box } from '@mui/material';
+import { Box,Grid,Button,Link } from '@mui/material';
 import { useState } from 'react';
 
 import { DateTime } from 'luxon';
@@ -138,12 +138,21 @@ export default function InputPage() {
     // let [currentAliceAllocation, currentBobAllocation] = makeBothAllocation(currentTaskRepartition);
     // let [adjustedWinnerAliceAllocation, adjustedWinnerBobAllocation] = makeBothAllocation(adjustedWinnerTaskRepartition);
     // let [leastChangeAliceAllocation, leastChangeBobAllocation] = makeBothAllocation(leastChangeAllocationTaskRepartition);
-    
+
+    // 上までスクロール
+    const scrollToTop = () => {
+        // 単純なTopは固定されているので、内部をスクロールさせる。
+        document.getElementById("input-panel").scrollIntoView();
+    };
+
     return (
-        <div className={styles.inputPanel}>
+        <div className={styles.inputPanel} id="input-panel">
             <Tabs value={currentTab} 
-            sx={{ position: 'sticky', top: '10px', backgroundColor: 'white', zIndex: 50000, borderRadius: '5px' }} 
-            onChange={ (_, newValue) => setCurrentTab(newValue) }
+            sx={{ position: 'sticky', top: '10px', backgroundColor: 'whitesmoke', zIndex: 50000, borderRadius: '5px' }} 
+            onChange={ (_, newValue) => {
+                setCurrentTab(newValue);
+                scrollToTop();
+             }}
             centered
             variant="fullWidth"
             scrollButtons="auto"
@@ -176,16 +185,17 @@ export default function InputPage() {
               >
               </ResultTabComponent>
             </TabPanel>
-            {/* <Grid container spacing={12} justifyContent="center">
-                <Grid item xs={2} justifyContent="center">
-                    <Link href="/" passHref={true}><Button variant="contained" color="secondary">Cancel</Button></Link>
+            <Grid container spacing={3} justifyContent="center">
+                <Grid container item xs={6} justifyContent="flex-end">
+                    <Link href="/" passhref={true}><Button variant="outlined" color="secondary">キャンセル</Button></Link>
                 </Grid>
-                <Grid item xs={2} justifyContent="center">
-                    <Button variant="contained" color="secondary" disabled={currentTab === 3} onClick={() => {
-                        setCurrentTab(currentTab + 1)
-                    }}>Next</Button>
+                <Grid container item xs={6} justifyContent="flex-start">
+                    <Button variant="contained" color="primary" disabled={currentTab === 3} onClick={() => {
+                        setCurrentTab(currentTab + 1);
+                        scrollToTop();
+                    }}>次へ</Button>
                 </Grid>
-            </Grid> */}
+            </Grid>
         </div>
     );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,9 +21,14 @@ a {
   box-sizing: border-box;
 }
 
+.app-header {
+  height: 15vh;
+  max-height: 15vh;
+}
+
 .app-container {
-  height: 90vh;
-  max-height: 90vh;
+  height: 85vh;
+  max-height: 85vh;
   overflow: scroll;
 
   display: flex;
@@ -34,8 +39,8 @@ a {
 main {
   flex-grow: 1;
   flex-shrink: 1;
-  height: 90vh;
-  max-height: 90vh;
+  height: 85vh;
+  max-height: 85vh;
   
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
入力ページの最下部にタブを遷移するボタンと、入力をキャンセルしてトップページに戻るボタンを復活
タブを遷移した時と、スクロールし直したくないので、初期位置に戻すようにする
ボタンを追加すると画面からはみ出てしまうので、ヘッダーとapp-containerの割合を調整